### PR TITLE
Use `XDG_CACHE_HOME` first

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,8 @@ var path = require('path')
 var homedir = require('os-homedir')
 
 function linux (id) {
-  return process.env.XDG_CACHE_HOME || path.join(homedir(), '.cache', id)
+  var cacheHome = process.env.XDG_CACHE_HOME || path.join(homedir(), '.cache')
+  return path.join(cacheHome, id)
 }
 
 function darwin (id) {

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ var path = require('path')
 var homedir = require('os-homedir')
 
 function linux (id) {
-  return path.join(homedir(), '.cache', id)
+  return process.env.XDG_CACHE_HOME || path.join(homedir(), '.cache', id)
 }
 
 function darwin (id) {


### PR DESCRIPTION
Per the [XDG Base Directory Specification](https://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html), the `XDG_CACHE_HOME` environment variable should be used if defined — otherwise falling back to `$HOME/.cache`.