### PR TITLE
Remove os-homedir dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,18 +1,17 @@
 const os = require('os')
 const path = require('path')
-const homedir = require('os-homedir')
 
 function posix (id) {
-  const cacheHome = process.env.XDG_CACHE_HOME || path.join(homedir(), '.cache')
+  const cacheHome = process.env.XDG_CACHE_HOME || path.join(os.homedir(), '.cache')
   return path.join(cacheHome, id)
 }
 
 function darwin (id) {
-  return path.join(homedir(), 'Library', 'Caches', id)
+  return path.join(os.homedir(), 'Library', 'Caches', id)
 }
 
 function win32 (id) {
-  const appData = process.env.LOCALAPPDATA || path.join(homedir(), 'AppData', 'Local')
+  const appData = process.env.LOCALAPPDATA || path.join(os.homedir(), 'AppData', 'Local')
   return path.join(appData, id, 'Cache')
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1324,11 +1324,6 @@
         "wordwrap": "~1.0.0"
       }
     },
-    "os-homedir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
-    },
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -7,9 +7,7 @@
   "scripts": {
     "test": "standard && mocha"
   },
-  "dependencies": {
-    "os-homedir": "^1.0.1"
-  },
+  "dependencies": {},
   "devDependencies": {
     "mocha": "^5.2.0",
     "proxyquire": "^2.0.1",

--- a/test.js
+++ b/test.js
@@ -1,14 +1,14 @@
 /* eslint-env mocha */
 
 const assert = require('assert')
-const homedir = require('os-homedir')
+const os = require('os')
 const proxyquire = require('proxyquire')
 
 const platforms = [
-  ['darwin', `${homedir()}/Library/Caches/linusu`],
-  ['freebsd', `${homedir()}/.cache/linusu`],
-  ['linux', `${homedir()}/.cache/linusu`],
-  ['win32', `${homedir()}/AppData/Local/linusu/Cache`]
+  ['darwin', `${os.homedir()}/Library/Caches/linusu`],
+  ['freebsd', `${os.homedir()}/.cache/linusu`],
+  ['linux', `${os.homedir()}/.cache/linusu`],
+  ['win32', `${os.homedir()}/AppData/Local/linusu/Cache`]
 ]
 
 platforms.forEach(function (platform) {


### PR DESCRIPTION
Since node-cachedir only supports Node >= 6, the os-homedir module is no longer needed. (os.homedir() was added in Node 4)